### PR TITLE
refactor: Return `Result` from `run`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::process;
+use std::error::Error;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -13,7 +14,10 @@ fn main() {
     println!("Searching for {}", config.query);
     println!("In the file {}", config.filename);
 
-    run(config);
+    if let Err(err) = run(config) {
+        println!("Application error: {}", err);
+        process::exit(1);
+    }
 }
 
 struct Config {
@@ -33,9 +37,10 @@ impl Config {
     }
 }
 
-fn run(config: Config) {
-    let contents = fs::read_to_string(config.filename)
-        .expect("Something went wrong reading the file");
+fn run(config: Config) -> Result<(), Box<dyn Error>> {
+    let contents = fs::read_to_string(config.filename)?;
 
     println!("With text:\n{}", contents);
+
+    Ok(())
 }


### PR DESCRIPTION
- Change the return type of the `run` function
- Handle `Ok`/`Err` cases inside the `main`